### PR TITLE
Using --schema flag for having dump schema level granularity and make COPY less error prone

### DIFF
--- a/pg_sample
+++ b/pg_sample
@@ -435,9 +435,9 @@ my $dbh = connect_db(%opt) or croak "unable to connect to database";
 
 my $pg_version = pg_version;
 
-if ($opt{sample_schema} eq 'public') {
-  # TODO worth check if smbd won't destroy one of exisitin db schemas !!!!
-  die "Error: refusing to use 'public' schema for sampling.\n";
+if (index($opt{sample_schema}, "_pg_sample") == -1) {
+    # ``reduce`` the risk of overwrite or remove (when with --force) by accident existing db schemas
+    die "Error: --sample_schema have to contain '_pg_sample' suffix";
 }
 
 my ($schema_oid) = $dbh->selectrow_array(qq{
@@ -476,7 +476,11 @@ unless ($opt{'data-only'}) {
   local $ENV{PGPORT} = $opt{db_port};
   local $ENV{PGCLIENTENCODING} = $opt{encoding};
 
-  my $cmd = "pg_dump --schema-only";
+  my $cmd = "pg_dump --schema-only --password";
+  if ($opt{schema}) {
+    $cmd = $cmd . " --schema=$opt{schema}";
+  }
+
   system($cmd) == 0 or croak "command '$cmd' failed: $?";
 }
 
@@ -680,7 +684,7 @@ foreach my $name (keys %seq) {
 print <<EOF;
 
 SET client_encoding = '$opt{encoding}';
-SET standard_conforming_strings = off;
+-- SET standard_conforming_strings = off; -- NOTE: commented out (will use the default set to on)
 SET check_function_bodies = false;
 SET client_min_messages = warning;
 SET escape_string_warning = off;
@@ -691,6 +695,8 @@ notice "Exporting sequences\n";
 print "\n";
 foreach my $name (sort keys %seq) {
   my $constant = quote_constant($name);
+  my ($schema_name, $table_name) = split('\.', $name, 2);
+  next if ($opt{schema}) && ($schema_name ne '"'.$opt{schema}.'"');
   print "SELECT pg_catalog.setval($constant, $seq{$name});\n";
 }
 print "\n";
@@ -708,8 +714,13 @@ foreach my $table (@tables) {
     my ($count) = $dbh->selectrow_array("SELECT count(*) FROM $sample_table");
     notice "Exporting data from $sample_table ($count)\n";
   }
-  print "COPY $table FROM stdin;\n";
-  $dbh->do(qq{ COPY $sample_table TO STDOUT });
+  my ($schema_name, $table_name) = split('\.', $table, 2);
+  my $cleaned_table_name = substr $table_name, 1, -1;
+  my $cleaned_schema_name = substr $schema_name, 1, -1;
+  my ($q) = "SELECT string_agg(quote_ident(column_name), ',') FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '$cleaned_table_name' AND TABLE_SCHEMA = '$cleaned_schema_name'";
+  my ($column_names_to_keep_order) = $dbh->selectrow_array($q);
+  print "COPY $table ($column_names_to_keep_order) FROM stdin WITH CSV DELIMITER E'\\t' QUOTE '\b' ESCAPE '\\';\n";
+  $dbh->do(qq{ COPY $sample_table TO STDOUT WITH CSV DELIMITER E'\\t' QUOTE '\b' ESCAPE '\\'});
   my $buffer = '';
   print $buffer while $dbh->pg_getcopydata($buffer) >= 0;
   print "\\.\n\n";


### PR DESCRIPTION
Using --schema flag for having dump schema level granularity
improved per schema filtering, make COPY less error prone
changed DELIMITER, QUOTE and ESCAPE for better handling of complicated data type fields (JSON in particular)
added explicitly the table collumns listed in COPY FROM to handle situation when the order of collumns differs between source and destination databases
added flag --password to explicitly ask for password when pg_dump needed (i.e each run without --data-only flag)
commented out standard_conforming_strings = off so this will be set to default value, which is on and is needed for import with \t delimiter
introduced the requirement that --sample_schema if specified must include _pg_sample in name to avoid risk of accidentally delete when used with --force