### PR TITLE
Add docker integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM perl:5.28.3
+
+RUN cpan -i DBI DBD::Pg
+
+RUN git clone https://github.com/mla/pg_sample
+
+WORKDIR pg_sample
+
+ENTRYPOINT ["tail"]
+CMD ["-f","/dev/null"]

--- a/README.md
+++ b/README.md
@@ -145,6 +145,32 @@ __\-password=__*password*
 
     Password to connect with.
 
+## Running `pg_sample` using a `docker` container
+
+We support running `pg_sample` as `docker` container in order to prevent cluttering your local file system with unwanted
+libraries. 
+
+### Build `docker` image
+
+From the root folder issue the following command to generate a runnable docker image:
+
+    docker build -t pg_sample .
+
+### Run containerized `pg_sample` 
+
+After executing the previous command you can proceed to spin up a `docker` container that will have `pg_sample`
+binaries available:
+
+    docker run --network=host --name pg_sample --detach pg_sample tail -f /dev/null
+
+### Execute `pg_sample` against `docker` container 
+
+    docker exec --detach pg_sample ./pg_sample mydb --file myfile.sql
+
+### Copy `pg_sample` output from `docker` container to local file system:
+
+    docker cp pg_sample:/pg_sample/myfile.sql /tmp/myfile.sql
+
 # LICENSE
 
 This code is released under the Artistic License. See [perlartistic](http://search.cpan.org/perldoc?perlartistic).


### PR DESCRIPTION
The purpose of this PR is to prevent cluttering your file system with unnecessary `Perl` libraries by running `pg_sample` inside a docker container 