### PR TITLE
fix#27 2/2 : Docker build workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,37 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches:
+      - master
+      - dev  
+    tags:        
+      - v*
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: mla/pg_sample
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
       - name: Extract metadata (tags, labels) for Docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,5 @@ RUN apt-get update \
 && apt-get install -y postgresql-client \
 && cpan -i DBI DBD::Pg
 
-ENTRYPOINT ["tail"]
-CMD ["-f","/dev/null"]
+ENTRYPOINT ["pg_sample"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -167,27 +167,11 @@ From the root folder issue the following command to generate a runnable docker i
 After executing the previous command you can proceed to spin up a `docker` container that will have `pg_sample`
 binaries available:
 
-    sudo docker run --network=host --name pg_sample --detach pg_sample tail -f /dev/null
-
-### Execute `pg_sample` against `docker` container
-
-Example 1
-
-    sudo docker exec --detach pg_sample ./pg_sample mydb --file myfile.sql
-
-Example 2
-
-    sudo docker exec pg_sample /bin/bash -c "perl pg_sample -h localhost -U db_user -W db_password --file myfile.sql mydb"
-
-### Copy `pg_sample` output from `docker` container to local file system
-
-Copy the output file to your current directory:
-
-    sudo docker cp pg_sample:/app/myfile.sql .
+    sudo docker run --network=host --name pg_sample --detach pg_sample -h localhost -U db_user -W db_password -v $(pwd):/io --file /io/myfile.sql mydb
 
 ### Import output file to database
 
-    sudo -u postgres psql database_name < /tmp/myfile.sql
+    sudo -u postgres psql database_name < myfile.sql
 
 # LICENSE
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ From the root folder issue the following command to generate a runnable docker i
 After executing the previous command you can proceed to spin up a `docker` container that will have `pg_sample`
 binaries available:
 
-    sudo docker run --network=host --name pg_sample --detach pg_sample -h localhost -U db_user -W db_password -v $(pwd):/io --file /io/myfile.sql mydb
+    sudo docker run --network=host --detach -v "$(pwd):/io" pg_sample -h localhost -U db_user -W db_password --file /io/myfile.sql mydb
 
 ### Import output file to database
 

--- a/README.md
+++ b/README.md
@@ -148,30 +148,17 @@ __\-password=__*password*
 ## Running `pg_sample` using a `docker` container
 
 We support running `pg_sample` as `docker` container in order to prevent cluttering your local file system with unwanted
-libraries.
+libraries:
 
-### Clone the repository
-
-First you need to clone this repository into the machine where you want to build the image.
-
-    git clone https://github.com/mla/pg_sample.git
-
-### Build `docker` image
-
-From the root folder issue the following command to generate a runnable docker image:
-
-    sudo docker build -t pg_sample .
-
-### Run containerized `pg_sample` 
-
-After executing the previous command you can proceed to spin up a `docker` container that will have `pg_sample`
-binaries available:
-
-    sudo docker run --network=host --detach -v "$(pwd):/io" pg_sample -h localhost -U db_user -W db_password --file /io/myfile.sql mydb
+    sudo docker run --network=host --detach -v "$(pwd):/io" mla/pg_sample -h localhost -U db_user -W db_password --file /io/myfile.sql mydb
 
 ### Import output file to database
 
     sudo -u postgres psql database_name < myfile.sql
+
+### Docker image publishing procedure
+
+For any branch or git tag matching `v*`, a Docker image will automatically be pushed to the dockerhub using github workflows.
 
 # LICENSE
 


### PR DESCRIPTION
(note : this contains commits of #28)

Adds an automated docker image build/push workflow for each tag.

For this to work, you need to create a dockerhub account `mla` and create a repo `pg_sample`.
Then, you need to secrets in this github's repo called `DOCKERHUB_USERNAME` (with value `mla`) and `DOCKERHUB_TOKEN` (with value a token generated from dockerhub)

With that, hopefully you'll get automated builds and pushes of images, making it more easy for users to use you tool without having to checkout/build the image locally.

It will probably not work on the first try though (as we can only start testing once you've done those steps), but am available to help fiddling once this is merged.

Also, for best results, you should start versioning your tool (making git tags every now and then), so that users can rely on a specific docker tag instead of using `latest`, which is not reliable as it could change behavior over time.