### PR TITLE
Allow fractional percentage values

### DIFF
--- a/pg_sample
+++ b/pg_sample
@@ -600,7 +600,7 @@ while (my $row = lower_keys($sth->fetchrow_hashref)) {
         my $percent = 100 * $_->[1] / $table_num_rows;
         $tablesample = "TABLESAMPLE BERNOULLI ($percent)";
       }
-    } elsif ($_->[1] =~ /^\d+%$/) { # percent value turned into LIMIT
+    } elsif ($_->[1] =~ /^\d+(\.\d+)?%$/) { # percent value turned into LIMIT
       if (not $opt{random} or $pg_version < version->declare('9.5')) {
         my ($table_num_rows) = $dbh->selectrow_array(qq{ SELECT count(*) FROM $table });
         my $percent = (substr $_->[1], 0, (length $_->[1]) - 1) / 100;


### PR DESCRIPTION
I attempted to specify `--limit='some_table = 0.01%'` to a large table of mine, but doing so causes the term `0.01%` to be treated as a subselect. 