### PR TITLE
Update Perl base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM perl:5.28.3
+FROM perl:5.38
 
 WORKDIR /app
 


### PR DESCRIPTION
Among various benefits moves off a soon-to-be obsolete version of Debian and adds support for postgres versions up to 16.

Fixes mla/pg_sample#50

Test output:
```
1..15
 set_config 
------------
 
(1 row)

 setval 
--------
      1
(1 row)

 setval 
--------
      1
(1 row)

ok 1 - child1 should have 100 rows
ok 2 - child2 should have 100 rows
ok 3 - child3 should have 100 rows
ok 4 - child4 should have 100 rows
ok 5 - child5 should have 100 rows
ok 6 - child6 should have 100 rows
ok 7 - child7 should have 100 rows
ok 8 - child8 should have 100 rows
ok 9 - child9 should have 100 rows
ok 10 - child10 should have 100 rows
ok 11 - all parent rows should be fetched due to FKs
ok 12 - escaping
ok 13 - ordered test case broken, this should return by clustered order
ok 14 - long table name should have 10 rows
 set_config 
------------
 
(1 row)

 setval 
--------
      1
(1 row)

 setval 
--------
      1
(1 row)

ok 15 - results should be ordered
```