### PR TITLE
Updated readme with description of how to import sql dump file into db

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,14 @@ __\-password=__*password*
 
     Password to connect with.
 
+## Importing dump into database
+
+You can import the dumped data directly into your PostgreSQL database using the psql command-line tool. It allows us to connect to our database and execute the commands from the generated SQL file. Example:
+
+```
+psql -h localhost -p 5432 -U postgres -d sampledb -f "/path/to/db_dump.sql"
+```
+
 ## Using with Docker
 
 We support running `pg_sample` as a `docker` container:


### PR DESCRIPTION
While using the tool, I successfully managed to dump my database into an SQL file, but afterwards, I had trouble figuring out how to import the dump into a new database. I found the solution to my problem by using the psql command-line tool. I think having this part in the documentation would be helpful for other users.

@mla 