### PR TITLE
Dockerfile update to install specific version of pg client tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,14 @@ WORKDIR /app
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=TRUE
+ARG POSTGRES_VERSION=17
 
 RUN apt-get update \
   && apt-get install -y wget lsb-release \
   && /bin/bash -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' \
   && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
   && apt-get update \
-  && apt-get install -y postgresql-client \
+  && apt-get install -y postgresql-client-$POSTGRES_VERSION \
   && /usr/local/bin/cpanm DBI DBD::Pg
 
 COPY . .


### PR DESCRIPTION
Running the existing image against a postgres 15 database results in 

```
pg_dump: error: server version: 15.8 (Debian 15.8-1.pgdg120+1); pg_dump version: 14.0 (Debian 14.0-1.pgdg100+1)
pg_dump: error: aborting because of server version mismatch
```

This update to the Dockerfile allows using a build arg to specify the version of postgres you want to install. You could use this to build one for each version of postgres.

According to https://wiki.postgresql.org/wiki/Apt, the versions currently available in the apt repo are 10, 11, 12, 13, 14, 15, 16, 17, 18 devel