### PR TITLE
Return a proper exit code if an error occurs

### DIFF
--- a/pg_sample
+++ b/pg_sample
@@ -211,6 +211,8 @@ $SIG{TERM} = $SIG{INT} = $SIG{QUIT} = $SIG{HUP} = sub {
   die "Received signal '$signal'; cleaning up and terminating.\n";
 };
 
+$SIG{__DIE__} = sub { our @reason = @_ };
+
 BEGIN {
   # Encapsulate a fully-qualified Postgresql table name
   package Table;
@@ -943,6 +945,8 @@ foreach my $table (@tables) {
 print "\n";
 
 END {
+  our @reason;
+
   # remove sample tables unless requested not to
   if ($created_schema && !$opt{keep}) {
     notice "Dropping sample schema $opt{sample_schema}\n";
@@ -950,5 +954,9 @@ END {
   }
 
   notice "Done.\n";
-  exit 0;
+  if (@reason) {
+    exit 1;
+  } else {
+    exit 0;
+  }
 }


### PR DESCRIPTION
My perl is super rusty so I'm not sure if this is the best way to do this.

We had an issue recently where pg_sample encountered an error and exited. Unfortunately the END block does `exit 0;` so our script that runs pg_sample thought that it had finished successfully and continued on. To fix this I've added a `$SIG{__DIE__}` handler that records the error to `@reason`. Then in the END block I check if `@reason` is set and if so exit with code 1 to signify an error occurred.