### PR TITLE
Huge tables (WIP)

### DIFF
--- a/pg_sample
+++ b/pg_sample
@@ -124,6 +124,14 @@ increase the running time of the script.
 
 Schema name to use for the sample database (defaults to _pg_sample).
 
+=item B<--sampling_method=>I<method name>
+
+Sampling method used to select samples, either 'BERNOULLI' or 'SYSTEM'.
+Defaults to BERNOULLI, the most random method.
+SYSTEM may speed up the sampling phase on a huge database, at the
+potential price of a less-random sample.
+Implicitly enables --random.
+
 =item B<--schema=>I<schema>
 
 Limit sampling to the specified schema. By default, all schemas are sampled.
@@ -509,6 +517,7 @@ sub notice (@) {
   random        => 0,
   schema        => undef,
   sample_schema => '_pg_sample',
+	sampling_method => undef,
   verbose       => 0,
 );
 
@@ -530,7 +539,8 @@ GetOptions(\%opt,
   "ordered_desc|ordered-desc",
   "ordered_asc|ordered-asc",
   "random",
-  "sample_schema=s",
+	"sample_schema=s",
+	"sampling_method=s",
   "schema=s",
   "trace",
   "verbose|v",
@@ -546,6 +556,11 @@ if ($opt{help}) {
   require Pod::Usage;
   Pod::Usage::pod2usage(-verbose => 2);
   exit 0;
+}
+
+if (defined $opt{sampling_method}) {
+	die "Option sampling-method accepts either 'BERNOULLI' or 'SYSTEM'" if ('BERNOULLI' ne $opt{sampling_method} and 'SYSTEM' ne $opt{sampling_method});
+	$opt{random}=1;
 }
 
 $opt{ordered} = $opt{ordered_desc} ? 'DESC'
@@ -693,7 +708,7 @@ foreach my $row (@{$table_info}) {
           SELECT greatest(count(*), ?) FROM $table
         }, undef, $_->[1]);
         my $percent = 100 * $_->[1] / $table_num_rows;
-        $tablesample = "TABLESAMPLE BERNOULLI ($percent)";
+        $tablesample = "TABLESAMPLE $opt{sampling_method} ($percent)";
       }
     } elsif ($_->[1] =~ /^\d+(\.\d+)?%$/) { # percent value turned into LIMIT
       if (not $opt{random} or $pg_version < version->declare('9.5')) {
@@ -704,7 +719,7 @@ foreach my $row (@{$table_info}) {
         $limit = "LIMIT $total_rows";
       } else {
         my $percent = (substr $_->[1], 0, (length $_->[1]) - 1);
-        $tablesample = "TABLESAMPLE BERNOULLI ($percent)";
+        $tablesample = "TABLESAMPLE $opt{sampling_method} ($percent)";
       }
     } else { # otherwise treated as subselect
       $where = "($_->[1])";

--- a/pg_sample
+++ b/pg_sample
@@ -510,6 +510,7 @@ sub notice (@) {
 
 
 %opt = (
+approxcount => 0,
   db_host       => '',
   db_port       => '',
   keep          => 0,
@@ -641,6 +642,15 @@ unless ($opt{'data-only'}) {
 
 # If running PostgreSQL 9.1 or later, use UNLOGGED tables
 my $unlogged = $pg_version >= version->declare('9.1') ? 'UNLOGGED' : '';
+
+# Ensuring that the user can read (GRANT...) the 'pg_class' table
+eval {
+	$dbh->selectrow_array(qq{SELECT 1 FROM pg_class LIMIT 1")});
+};
+if ($@) {
+	warn "I cannot read from the 'pg_class' table, therefore I cannot honor --approxcount: $@\n";
+	$opt{approxcount}=0;
+}
 
 notice "Creating sample schema $opt{sample_schema}\n";
 $dbh->do(qq{ CREATE SCHEMA $opt{sample_schema} });
@@ -834,7 +844,8 @@ sub APPROX_table_tuples_count($$) {
 	my $dbh = ${ shift() }; # dereference the reference to DBI session handle
 	my $tablename = $dbh->quote_identifier(shift);
 
-	my ($count) = $dbh->do(qq{SELECT c.reltuples::bigint FROM pg_class c WHERE c.relname = $tablename AND c.relkind = 'r'});
+	# todo: take into account the last ANALYZE age, sizeof(tuples)/sizeof(shema def)...
+	my ($count) = $dbh->do(qq{SELECT c.reltuples::bigint FROM pg_class WHERE relname = $tablename AND relkind = 'r'});
 	if ($count < 1) { # may indicate that the evaluated amount is dubious
 		$dbh->do(qq{ANALYZE $tablename});
 		($count) = $dbh->do(qq{SELECT c.reltuples::bigint AS approx_row_count FROM pg_class c WHERE c.relname = $tablename AND c.relkind = 'r'});

--- a/pg_sample
+++ b/pg_sample
@@ -1,5 +1,12 @@
 #!/usr/bin/env perl
 
+use strict;
+use warnings;
+use Carp;
+use Getopt::Long qw/ GetOptions :config no_ignore_case /;
+use DBI;
+use DBD::Pg 2.0.0;
+
 our $VERSION = "1.17";
 
 =head1 NAME
@@ -205,13 +212,6 @@ Maurice Aubrey <maurice.aubrey@gmail.com>
 # Finally, the database schema and sample data are output, renaming the sample
 # table names to reflect the original database.
 
-use strict;
-use warnings;
-use Carp;
-use Getopt::Long qw/ GetOptions :config no_ignore_case /;
-use DBI;
-use DBD::Pg 2.0.0;
-
 our $MAX_IDENTIFIER_LENGTH = 63;
 
 $SIG{TERM} = $SIG{INT} = $SIG{QUIT} = $SIG{HUP} = sub {
@@ -348,7 +348,7 @@ my %opt; # closure; all functions have access to options
         PrintError       => 0,
         HandleError      => sub { confess( shift ) },
       },
-    ) or croak "db connection failed!";
+    ) or croak "DB connection failed!";
 
     $dbh->trace(1) if defined $opt{trace};
 
@@ -561,7 +561,7 @@ if ($opt{help}) {
 if (defined $opt{sampling_method}) {
 	$opt{sampling_method}=uc($opt{sampling_method});
 	die "Option sampling-method accepts either 'BERNOULLI' or 'SYSTEM'" if ('BERNOULLI' ne $opt{sampling_method} and 'SYSTEM' ne $opt{sampling_method});
-	$opt{random}=1; # implied
+	$opt{random}=2; # implied
 } else {
 	$opt{sampling_method}='BERNOULLI' if $opt{random}; # default method
 }
@@ -571,11 +571,12 @@ $opt{ordered} = $opt{ordered_desc} ? 'DESC'
               : $opt{ordered}      ? 'DESC'
               : undef;
 if ($opt{random} && $opt{ordered}) {
-  print("Error: --random and --ordered are mutually exclusive");
+	warn "you used --sampling_method, therefore --random was automatically enabled " if ( 2 == $opt{random} );
+  warn "Error: --random and --ordered are mutually exclusive";
   exit 1;
 }
 
-@ARGV or die "\nUsage: $0 [ option... ] [ dbname ]\n\n\t" .
+@ARGV or die "Usage: $0 [ option... ] [ dbname ]\n\n\t" .
              "$0 --help for detailed options\n";
 
 push @{ $opt{limit} }, ".* = 100 "; # append default limit rule

--- a/pg_sample
+++ b/pg_sample
@@ -828,12 +828,14 @@ sub should_skip_insert_for_fk ($) {
   return 0;  # Do not skip by default
 }
 
+# Obtains the amount of tuples in a table.
+# May over/under-estimate if the table needs an ANALYZE pass.
 sub APPROX_table_tuples_count($$) {
 	my $dbh = ${ shift() }; # dereference the reference to DBI session handle
 	my $tablename = $dbh->quote_identifier(shift);
 
-	my ($count) = $dbh->do(qq{SELECT c.reltuples::bigint AS approx_row_count FROM pg_class c WHERE c.relname = $tablename AND c.relkind = 'r'});
-	if ($count < 1) {
+	my ($count) = $dbh->do(qq{SELECT c.reltuples::bigint FROM pg_class c WHERE c.relname = $tablename AND c.relkind = 'r'});
+	if ($count < 1) { # may indicate that the evaluated amount is dubious
 		$dbh->do(qq{ANALYZE $tablename});
 		($count) = $dbh->do(qq{SELECT c.reltuples::bigint AS approx_row_count FROM pg_class c WHERE c.relname = $tablename AND c.relkind = 'r'});
 	}

--- a/pg_sample
+++ b/pg_sample
@@ -559,8 +559,11 @@ if ($opt{help}) {
 }
 
 if (defined $opt{sampling_method}) {
+	$opt{sampling_method}=uc($opt{sampling_method});
 	die "Option sampling-method accepts either 'BERNOULLI' or 'SYSTEM'" if ('BERNOULLI' ne $opt{sampling_method} and 'SYSTEM' ne $opt{sampling_method});
-	$opt{random}=1;
+	$opt{random}=1; # implied
+} else {
+	$opt{sampling_method}='BERNOULLI' if $opt{random}; # default method
 }
 
 $opt{ordered} = $opt{ordered_desc} ? 'DESC'

--- a/pg_sample
+++ b/pg_sample
@@ -50,6 +50,12 @@ import errors.
 
 =over
 
+=item B<--approxcount>
+
+In order to count the tuples stored in a table do not read them but read the
+count stored in PostgreSQL's 'pg_class' table.  It may be way off is the table
+needs an ANALYZE pass.
+
 =item I<dbname>
 
 Specifies the database to sample. If not specified, uses the
@@ -643,14 +649,15 @@ unless ($opt{'data-only'}) {
 # If running PostgreSQL 9.1 or later, use UNLOGGED tables
 my $unlogged = $pg_version >= version->declare('9.1') ? 'UNLOGGED' : '';
 
-# Ensuring that the user can read (GRANT...) the 'pg_class' table
-eval {
-	$dbh->selectrow_array(qq{SELECT 1 FROM pg_class LIMIT 1")});
-};
-if ($@) {
-	warn "I cannot read from the 'pg_class' table, therefore I cannot honor --approxcount: $@\n";
-	$opt{approxcount}=0;
-}
+# # Useless(?)
+# # Ensuring that the user can read (GRANT...) the 'pg_class' table
+# eval {
+#   $dbh->selectrow_array(qq{SELECT 1 FROM pg_class LIMIT 1")});
+# };
+# if ($@) {
+#   warn "I cannot read from the 'pg_class' table, therefore I cannot honor --approxcount: $@\n";
+#   $opt{approxcount}=0;
+# }
 
 notice "Creating sample schema $opt{sample_schema}\n";
 $dbh->do(qq{ CREATE SCHEMA $opt{sample_schema} });
@@ -696,6 +703,14 @@ foreach my $row (@{$table_info}) {
       AND is_generated='NEVER'
       ORDER BY ordinal_position
   }, { Slice => {} }, ($tname, $sname) ) ];
+
+	my $sthTabelExistsP = $dbh->table_info('', undef, $tname, 'TABLE'); # FOREIGN TABLE, VIEW, MATERIALIZED VIEW
+  my $table_exists = keys (@{$sthTabelExistsP->fetchall_arrayref({})});
+  $sthTabelExistsP->finish();
+  if ( 0>= $table_exists ) {
+    notice "\nThe '$tname' table vanished\n" if ($opt{verbose});
+    next;
+  }
 
   my $table = Table->new($sname, $tname, $columns);
   push @tables, $table;
@@ -782,6 +797,7 @@ foreach my $row (@{$table_info}) {
   }
 }
 
+
 # Find foreign keys
 my @fks;
 foreach my $table (@tables) {
@@ -821,21 +837,33 @@ foreach my $fk (@fks) {
 }
 
 
+{
+	my $warn_last_table=''; # To avoid repeating a notice about the same table
+	
 # Skip FK inserts if entire table is being included anyway
 # (useful for cases where we don't support equality operator)
 sub should_skip_insert_for_fk ($) {
   my $table_name = shift;
   
   $table_name =~ s/"\."/\./g;
-  notice "$table_name\n";
+		my $already_noticed;
+		if ($warn_last_table ne $table_name) {
+			# The last notice wasn't about this table
+			$warn_last_table = $table_name;
+			$already_noticed=0;
+		}	else {
+			$already_noticed=1;
+		}		
+    notice "$table_name\n" if (! $already_noticed);
   foreach my $limit (@limits) {
     my ($regex, $action) = @$limit;
     if ($table_name =~ $regex && $action eq '*') {
-      notice "Skipping $table_name as all data is imported\n";
+				notice "Skipping $table_name (regex $regex) as all data is imported\n" if (! $already_noticed);
       return 1;  # Skip if it matches the regex and action is '*'
     }
   }
   return 0;  # Do not skip by default
+}
 }
 
 # Obtains the amount of tuples in a table.

--- a/pg_sample
+++ b/pg_sample
@@ -522,6 +522,7 @@ sub notice (@) {
 );
 
 GetOptions(\%opt,
+  "approxcount",
   "data-only|data_only|a",
   "db_name|db-name=s",
   "db_user|db-user|db_username|db-username|username|U=s",
@@ -827,6 +828,17 @@ sub should_skip_insert_for_fk ($) {
   return 0;  # Do not skip by default
 }
 
+sub APPROX_table_tuples_count($$) {
+	my $dbh = ${ shift() }; # dereference the reference to DBI session handle
+	my $tablename = $dbh->quote_identifier(shift);
+
+	my ($count) = $dbh->do(qq{SELECT c.reltuples::bigint AS approx_row_count FROM pg_class c WHERE c.relname = $tablename AND c.relkind = 'r'});
+	if ($count < 1) {
+		$dbh->do(qq{ANALYZE $tablename});
+		($count) = $dbh->do(qq{SELECT c.reltuples::bigint AS approx_row_count FROM pg_class c WHERE c.relname = $tablename AND c.relkind = 'r'});
+	}
+	return $count;
+}
 
 # Keep inserting rows to satisfy any fk constraints until no more
 # are inserted. This should handle circular references.


### PR DESCRIPTION
My goal is to speed things up when the database is "huge" (total size way above the host's RAM size).

Approach number 1: offering to the user a way to let pg_sample use the "SYSTEM" option instead of "BERNOULLI".  This patch does it.  It seems OK but I didn't test thoroughly.

Approach number 2: obtaining the amount of tuples in a table using meta-information collected and stored during an ANALYZE pass, instead of the usual SELECT COUNT() way which often implies reading the whole table.  The patch offers provisions to do so, but most of the work has to be done.  Let me know if it seems interesting to you.

There are also various modifications made in "janitor" mode.